### PR TITLE
Hardware interface framework

### DIFF
--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -12,59 +12,72 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(hardware_interface REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(rclcpp REQUIRED)
 find_package(ur_client_library REQUIRED)
 find_package(ur_dashboard_msgs REQUIRED)
 
 include_directories(
   include
-  ${Boost_INCLUDE_DIRS}
 )
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
+  hardware_interface
+  pluginlib
+  rclcpp
+  ur_client_library
   ur_dashboard_msgs
 )
 
 add_library(ur_robot_driver_plugin
+  SHARED
   src/dashboard_client_ros.cpp
   src/hardware_interface.cpp
 )
-target_link_libraries(ur_robot_driver_plugin ur_client_library::urcl)
-ament_target_dependencies(ur_robot_driver_plugin ${${PROJECT_NAME}_EXPORTED_TARGETS} ${THIS_PACKAGE_INCLUDE_DEPENDS})
-
-add_executable(ur_robot_driver_node
-  src/dashboard_client_ros.cpp
-  src/hardware_interface.cpp
-  src/hardware_interface_node.cpp
+target_link_libraries(
+  ur_robot_driver_plugin
+  ur_client_library::urcl
 )
-target_link_libraries(ur_robot_driver_node ${catkin_LIBRARIES} ur_client_library::urcl)
-ament_target_dependencies(ur_robot_driver_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${THIS_PACKAGE_INCLUDE_DEPENDS})
-
-add_executable(dashboard_client
-  src/dashboard_client_ros.cpp
-  src/dashboard_client_node.cpp
+target_include_directories(
+  ur_robot_driver_plugin
+  PRIVATE
+  include
 )
-target_link_libraries(dashboard_client ${catkin_LIBRARIES} ur_client_library::urcl)
-ament_target_dependencies(dashboard_client ${${PROJECT_NAME}_EXPORTED_TARGETS} ${THIS_PACKAGE_INCLUDE_DEPENDS})
-
-add_executable(robot_state_helper
-  src/robot_state_helper.cpp
-  src/robot_state_helper_node.cpp
+ament_target_dependencies(
+  ur_robot_driver_plugin
+  ${${PROJECT_NAME}_EXPORTED_TARGETS}
+  ${THIS_PACKAGE_INCLUDE_DEPENDS}
 )
-target_link_libraries(robot_state_helper ${catkin_LIBRARIES} ur_client_library::urcl)
-ament_target_dependencies(robot_state_helper ${${PROJECT_NAME}_EXPORTED_TARGETS} ${THIS_PACKAGE_INCLUDE_DEPENDS})
+pluginlib_export_plugin_description_file(hardware_interface hardware_interface_plugin.xml)
 
-if(CATKIN_ENABLE_TESTING)
-  find_package(rostest REQUIRED)
+# add_executable(ur_robot_driver_node
+#   src/dashboard_client_ros.cpp
+#   src/hardware_interface.cpp
+#   src/hardware_interface_node.cpp
+# )
+# target_link_libraries(ur_robot_driver_node ${catkin_LIBRARIES} ur_client_library::urcl)
+# ament_target_dependencies(ur_robot_driver_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
-  add_rostest(test/driver.test)
-endif()
+# add_executable(dashboard_client
+#   src/dashboard_client_ros.cpp
+#   src/dashboard_client_node.cpp
+# )
+# target_link_libraries(dashboard_client ${catkin_LIBRARIES} ur_client_library::urcl)
+# ament_target_dependencies(dashboard_client ${${PROJECT_NAME}_EXPORTED_TARGETS} ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
+# add_executable(robot_state_helper
+#   src/robot_state_helper.cpp
+#   src/robot_state_helper_node.cpp
+# )
+# target_link_libraries(robot_state_helper ${catkin_LIBRARIES} ur_client_library::urcl)
+# ament_target_dependencies(robot_state_helper ${${PROJECT_NAME}_EXPORTED_TARGETS} ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
-install(TARGETS ur_robot_driver_plugin ur_robot_driver_node robot_state_helper dashboard_client
-  ARCHIVE DESTINATION lib}
-  LIBRARY DESTINATION lib}
-  RUNTIME DESTINATION bin}
-)
+# install(TARGETS ur_robot_driver_plugin ur_robot_driver_node robot_state_helper dashboard_client
+#   ARCHIVE DESTINATION lib}
+#   LIBRARY DESTINATION lib}
+#   RUNTIME DESTINATION bin}
+# )
 
 install(PROGRAMS scripts/tool_communication
   DESTINATION bin
@@ -77,10 +90,6 @@ install(DIRECTORY config launch resources
 
 install(DIRECTORY include/
   DESTINATION include
-)
-
-install(FILES hardware_interface_plugin.xml
-  DESTINATION share/${PROJECT_NAME}
 )
 
 ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})

--- a/ur_robot_driver/config/ur5_controllers.yaml
+++ b/ur_robot_driver/config/ur5_controllers.yaml
@@ -1,136 +1,19 @@
-# Settings for ros_control control loop
-hardware_control_loop:
-   loop_hz: &loop_hz 125
 
-# Settings for ros_control hardware interface
-ur_hardware_interface:
-   joints: &robot_joints
-     - shoulder_pan_joint
-     - shoulder_lift_joint
-     - elbow_joint
-     - wrist_1_joint
-     - wrist_2_joint
-     - wrist_3_joint
+control_manager:
+  ros__parameters:
+    controllers:
+      - joint_trajectory_controller_position
 
-# Publish all joint states ----------------------------------
-joint_state_controller:
-   type:         joint_state_controller/JointStateController
-   publish_rate: *loop_hz
+    joint_trajectory_controller_position:
+      type: joint_trajectory_controller/JointTrajectoryController
 
-# Publish wrench ----------------------------------
-force_torque_sensor_controller:
-   type:         force_torque_sensor_controller/ForceTorqueSensorController
-   publish_rate: *loop_hz
-
-# Publish speed_scaling factor
-speed_scaling_state_controller:
-   type:         ur_controllers/SpeedScalingStateController
-   publish_rate: *loop_hz
-
-# Joint Trajectory Controller - position based -------------------------------
-# For detailed explanations of parameter see http://wiki.ros.org/joint_trajectory_controller
-scaled_pos_joint_traj_controller:
-   type: position_controllers/ScaledJointTrajectoryController
-   joints: *robot_joints
-   constraints:
-      goal_time: 0.6
-      stopped_velocity_tolerance: 0.05
-      shoulder_pan_joint: {trajectory: 0.2, goal: 0.1}
-      shoulder_lift_joint: {trajectory: 0.2, goal: 0.1}
-      elbow_joint: {trajectory: 0.2, goal: 0.1}
-      wrist_1_joint: {trajectory: 0.2, goal: 0.1}
-      wrist_2_joint: {trajectory: 0.2, goal: 0.1}
-      wrist_3_joint: {trajectory: 0.2, goal: 0.1}
-   stop_trajectory_duration: 0.5
-   state_publish_rate: *loop_hz
-   action_monitor_rate: 20
-
-pos_joint_traj_controller:
-   type: position_controllers/JointTrajectoryController
-   joints: *robot_joints
-   constraints:
-      goal_time: 0.6
-      stopped_velocity_tolerance: 0.05
-      shoulder_pan_joint: {trajectory: 0.2, goal: 0.1}
-      shoulder_lift_joint: {trajectory: 0.2, goal: 0.1}
-      elbow_joint: {trajectory: 0.2, goal: 0.1}
-      wrist_1_joint: {trajectory: 0.2, goal: 0.1}
-      wrist_2_joint: {trajectory: 0.2, goal: 0.1}
-      wrist_3_joint: {trajectory: 0.2, goal: 0.1}
-   stop_trajectory_duration: 0.5
-   state_publish_rate: *loop_hz
-   action_monitor_rate: 20
-
-scaled_vel_joint_traj_controller:
-   type: velocity_controllers/ScaledJointTrajectoryController
-   joints: *robot_joints
-   constraints:
-      goal_time: 0.6
-      stopped_velocity_tolerance: 0.05
-      shoulder_pan_joint: {trajectory: 0.1, goal: 0.1}
-      shoulder_lift_joint: {trajectory: 0.1, goal: 0.1}
-      elbow_joint: {trajectory: 0.1, goal: 0.1}
-      wrist_1_joint: {trajectory: 0.1, goal: 0.1}
-      wrist_2_joint: {trajectory: 0.1, goal: 0.1}
-      wrist_3_joint: {trajectory: 0.1, goal: 0.1}
-   gains:
-      #!!These values have not been optimized!!
-      shoulder_pan_joint:  {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-      shoulder_lift_joint: {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-      elbow_joint:         {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-      wrist_1_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-      wrist_2_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-      wrist_3_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-   # Use a feedforward term to reduce the size of PID gains
-   velocity_ff:
-      shoulder_pan_joint: 1.0
-      shoulder_lift_joint: 1.0
-      elbow_joint: 1.0
-      wrist_1_joint: 1.0
-      wrist_2_joint: 1.0
-      wrist_3_joint: 1.0
-   stop_trajectory_duration: 0.5
-   state_publish_rate: *loop_hz
-   action_monitor_rate: 20
-
-vel_joint_traj_controller:
-   type: velocity_controllers/JointTrajectoryController
-   joints: *robot_joints
-   constraints:
-      goal_time: 0.6
-      stopped_velocity_tolerance: 0.05
-      shoulder_pan_joint: {trajectory: 0.1, goal: 0.1}
-      shoulder_lift_joint: {trajectory: 0.1, goal: 0.1}
-      elbow_joint: {trajectory: 0.1, goal: 0.1}
-      wrist_1_joint: {trajectory: 0.1, goal: 0.1}
-      wrist_2_joint: {trajectory: 0.1, goal: 0.1}
-      wrist_3_joint: {trajectory: 0.1, goal: 0.1}
-   gains:
-      #!!These values have not been optimized!!
-      shoulder_pan_joint:  {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-      shoulder_lift_joint: {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-      elbow_joint:         {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-      wrist_1_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-      wrist_2_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-      wrist_3_joint:       {p: 5.0,  i: 0.05, d: 0.1, i_clamp: 1}
-   # Use a feedforward term to reduce the size of PID gains
-   velocity_ff:
-      shoulder_pan_joint: 1.0
-      shoulder_lift_joint: 1.0
-      elbow_joint: 1.0
-      wrist_1_joint: 1.0
-      wrist_2_joint: 1.0
-      wrist_3_joint: 1.0
-   stop_trajectory_duration: 0.5
-   state_publish_rate: *loop_hz
-   action_monitor_rate: 20
-
-# Pass an array of joint velocities directly to the joints
-joint_group_vel_controller:
-   type: velocity_controllers/JointGroupVelocityController
-   joints: *robot_joints
-
-robot_status_controller:
-   type: industrial_robot_status_controller/IndustrialRobotStatusController
-   handle_name: industrial_robot_status_handle
-   publish_rate: 10
+forward_command_controller_position:
+  ros__parameters:
+    joints:
+      - joint_1
+      - joint_2
+      - joint_3
+      - joint_4
+      - joint_5
+      - joint_6
+    interface_name: position

--- a/ur_robot_driver/hardware_interface_plugin.xml
+++ b/ur_robot_driver/hardware_interface_plugin.xml
@@ -1,5 +1,5 @@
 <library path="lib/libur_robot_driver_plugin">
-  <class name="ur_driver/HardwareInterface" type="ur_driver::HardwareInterface" base_class_type="hardware_interface::RobotHW">
+  <class name="ur_robot_driver/HardwareInterface" type="ur_robot_driver::HardwareInterface" base_class_type="hardware_interface::RobotHW">
     <description>
       Universal Robots ROS Driver as plugin
     </description>

--- a/ur_robot_driver/hardware_interface_plugin.xml
+++ b/ur_robot_driver/hardware_interface_plugin.xml
@@ -1,7 +1,9 @@
-<library path="lib/libur_robot_driver_plugin">
-  <class name="ur_robot_driver/HardwareInterface" type="ur_robot_driver::HardwareInterface" base_class_type="hardware_interface::RobotHW">
+<library path="ur_robot_driver_plugin">
+  <class name="ur_robot_driver/URHardwareInterface"
+         type="ur_robot_driver::URHardwareInterface"
+         base_class_type="hardware_interface::RobotHardwareInterface">
     <description>
-      Universal Robots ROS Driver as plugin
+		ROS2 Control System Driver for the Universal Robots series.
     </description>
   </class>
 </library>

--- a/ur_robot_driver/include/ur_robot_driver/dashboard_client_ros.h
+++ b/ur_robot_driver/include/ur_robot_driver/dashboard_client_ros.h
@@ -25,8 +25,7 @@
  */
 //----------------------------------------------------------------------
 
-#ifndef UR_ROBOT_DRIVER_ROS_DASHBOARD_CLIENT_H_INCLUDED
-#define UR_ROBOT_DRIVER_ROS_DASHBOARD_CLIENT_H_INCLUDED
+#pragma once
 
 #include <regex>
 
@@ -44,7 +43,7 @@
 #include <ur_dashboard_msgs/srv/popup.hpp>
 #include <ur_dashboard_msgs/srv/raw_request.hpp>
 
-namespace ur_driver
+namespace ur_robot_driver
 {
 /*!
  * \brief ROS wrapper for UR's dashboard server access. Many (not necessarily all) dashboard
@@ -53,5 +52,4 @@ namespace ur_driver
 class DashboardClientROS
 {
 };
-}  // namespace ur_driver
-#endif  // ifndef UR_ROBOT_DRIVER_ROS_DASHBOARD_CLIENT_H_INCLUDED
+}  // namespace ur_robot_driver

--- a/ur_robot_driver/include/ur_robot_driver/hardware_interface.h
+++ b/ur_robot_driver/include/ur_robot_driver/hardware_interface.h
@@ -26,6 +26,51 @@
 //----------------------------------------------------------------------
 #pragma once
 
+// System
+#include <memory>
+#include <vector>
+
+// ros2_control hardware_interface
+#include "hardware_interface/hardware_info.hpp"
+#include "hardware_interface/components/actuator.hpp"
+#include "hardware_interface/components/sensor.hpp"
+#include "hardware_interface/components/system_interface.hpp"
+#include "hardware_interface/types/hardware_interface_return_values.hpp"
+#include "hardware_interface/types/hardware_interface_status_values.hpp"
+#include "hardware_interface/visibility_control.h"
+
+#include "rclcpp/macros.hpp"
+
+using hardware_interface::components::Actuator;
+using hardware_interface::components::Sensor;
+using hardware_interface::HardwareInfo;
+using hardware_interface::status;
+using hardware_interface::return_type;
+
+namespace hardware_interface
+{
+// TODO(andyz): This is likely to be incorporated in ros2_control, may not need to define it here
+class BaseSystemHardwareInterface : public components::SystemInterface
+{
+public:
+  return_type configure(const HardwareInfo& system_info) override
+  {
+    info_ = system_info;
+    status_ = status::CONFIGURED;
+    return return_type::OK;
+  }
+
+  status get_status() const final
+  {
+    return status_;
+  }
+
+protected:
+  HardwareInfo info_;
+  status status_;
+};
+}  // namespace hardware_interface
+
 namespace ur_robot_driver
 {
 /*!
@@ -33,8 +78,20 @@ namespace ur_robot_driver
  * driver. It contains the read and write methods of the main control loop and registers various ROS
  * topics and services.
  */
-class HardwareInterface
+class URHardwareInterface final : public hardware_interface::components::SystemInterface
 {
+public:
+  RCLCPP_SHARED_PTR_DEFINITIONS(URHardwareInterface);
+
+  return_type configure(const HardwareInfo & system_info) override;
+
+  return_type start() override;
+
+  return_type stop() override;
+
+  return_type read() override;
+
+  return_type write() override;
 };
 
 }  // namespace ur_robot_driver

--- a/ur_robot_driver/include/ur_robot_driver/hardware_interface.h
+++ b/ur_robot_driver/include/ur_robot_driver/hardware_interface.h
@@ -41,35 +41,11 @@
 
 #include "rclcpp/macros.hpp"
 
+using hardware_interface::HardwareInfo;
+using hardware_interface::return_type;
+using hardware_interface::status;
 using hardware_interface::components::Actuator;
 using hardware_interface::components::Sensor;
-using hardware_interface::HardwareInfo;
-using hardware_interface::status;
-using hardware_interface::return_type;
-
-namespace hardware_interface
-{
-// TODO(andyz): This is likely to be incorporated in ros2_control, may not need to define it here
-class BaseSystemHardwareInterface : public components::SystemInterface
-{
-public:
-  return_type configure(const HardwareInfo& system_info) override
-  {
-    info_ = system_info;
-    status_ = status::CONFIGURED;
-    return return_type::OK;
-  }
-
-  status get_status() const final
-  {
-    return status_;
-  }
-
-protected:
-  HardwareInfo info_;
-  status status_;
-};
-}  // namespace hardware_interface
 
 namespace ur_robot_driver
 {
@@ -83,15 +59,26 @@ class URHardwareInterface final : public hardware_interface::components::SystemI
 public:
   RCLCPP_SHARED_PTR_DEFINITIONS(URHardwareInterface);
 
-  return_type configure(const HardwareInfo & system_info) override;
+  hardware_interface::return_type configure(const HardwareInfo& system_info) final
+  {
+    info_ = system_info;
+    status_ = status::CONFIGURED;
+    return return_type::OK;
+  }
 
-  return_type start() override;
+  status get_status() const final
+  {
+    return status_;
+  }
 
-  return_type stop() override;
+  return_type start() final;
+  return_type stop() final;
+  return_type read() final;
+  return_type write() final;
 
-  return_type read() override;
-
-  return_type write() override;
+protected:
+  HardwareInfo info_;
+  status status_;
 };
 
 }  // namespace ur_robot_driver

--- a/ur_robot_driver/include/ur_robot_driver/hardware_interface.h
+++ b/ur_robot_driver/include/ur_robot_driver/hardware_interface.h
@@ -39,6 +39,7 @@
 #include "hardware_interface/types/hardware_interface_status_values.hpp"
 #include "hardware_interface/visibility_control.h"
 
+// ROS
 #include "rclcpp/macros.hpp"
 
 using hardware_interface::HardwareInfo;
@@ -54,7 +55,7 @@ namespace ur_robot_driver
  * driver. It contains the read and write methods of the main control loop and registers various ROS
  * topics and services.
  */
-class URHardwareInterface final : public hardware_interface::components::SystemInterface
+class URHardwareInterface : public hardware_interface::components::SystemInterface
 {
 public:
   RCLCPP_SHARED_PTR_DEFINITIONS(URHardwareInterface);
@@ -75,7 +76,6 @@ protected:
   HardwareInfo info_;
   status status_;
   std::vector<double> joint_angle_commands_, current_joint_angles_;
-
 };
 
 }  // namespace ur_robot_driver

--- a/ur_robot_driver/include/ur_robot_driver/hardware_interface.h
+++ b/ur_robot_driver/include/ur_robot_driver/hardware_interface.h
@@ -24,10 +24,9 @@
  *
  */
 //----------------------------------------------------------------------
-#ifndef UR_DRIVER_HARDWARE_INTERFACE_H_INCLUDED
-#define UR_DRIVER_HARDWARE_INTERFACE_H_INCLUDED
+#pragma once
 
-namespace ur_driver
+namespace ur_robot_driver
 {
 /*!
  * \brief The HardwareInterface class handles the interface between the ROS system and the main
@@ -38,6 +37,4 @@ class HardwareInterface
 {
 };
 
-}  // namespace ur_driver
-
-#endif  // ifndef UR_DRIVER_HARDWARE_INTERFACE_H_INCLUDED
+}  // namespace ur_robot_driver

--- a/ur_robot_driver/include/ur_robot_driver/hardware_interface.h
+++ b/ur_robot_driver/include/ur_robot_driver/hardware_interface.h
@@ -59,12 +59,7 @@ class URHardwareInterface final : public hardware_interface::components::SystemI
 public:
   RCLCPP_SHARED_PTR_DEFINITIONS(URHardwareInterface);
 
-  hardware_interface::return_type configure(const HardwareInfo& system_info) final
-  {
-    info_ = system_info;
-    status_ = status::CONFIGURED;
-    return return_type::OK;
-  }
+  hardware_interface::return_type configure(const HardwareInfo& system_info) final;
 
   status get_status() const final
   {
@@ -79,6 +74,8 @@ public:
 protected:
   HardwareInfo info_;
   status status_;
+  std::vector<double> joint_angle_commands_, current_joint_angles_;
+
 };
 
 }  // namespace ur_robot_driver

--- a/ur_robot_driver/include/ur_robot_driver/robot_state_helper.h
+++ b/ur_robot_driver/include/ur_robot_driver/robot_state_helper.h
@@ -24,8 +24,7 @@
  *
  */
 //----------------------------------------------------------------------
-#ifndef UR_ROBOT_DRIVER_ROS_ROBOT_STATE_HELPER_INCLUDED
-#define UR_ROBOT_DRIVER_ROS_ROBOT_STATE_HELPER_INCLUDED
+#pragma once
 
 #include <sstream>
 #include <ur_client_library/ur/datatypes.h>
@@ -33,7 +32,7 @@
 #include <ur_dashboard_msgs/msg/safety_mode.hpp>
 #include <ur_dashboard_msgs/action/set_mode.hpp>
 
-namespace ur_driver
+namespace ur_robot_driver
 {
 /*!
  * \brief A small helper class around the robot state (constisting of 'robot_mode' and
@@ -46,6 +45,4 @@ namespace ur_driver
 class RobotStateHelper
 {
 };
-}  // namespace ur_driver
-
-#endif  // ifndef UR_ROBOT_DRIVER_ROS_ROBOT_STATE_HELPER_INCLUDED
+}  // namespace ur_robot_driver

--- a/ur_robot_driver/launch/ur5_bringup.launch.py
+++ b/ur_robot_driver/launch/ur5_bringup.launch.py
@@ -1,0 +1,31 @@
+import os
+import xacro
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+def generate_launch_description():
+
+    ld = LaunchDescription()
+    description_package_path = get_package_share_directory('ur_description')
+    robot_description_file = os.path.join(description_package_path, 'urdf', 'ur5.urdf.xacro')
+
+    controller_package_path = get_package_share_directory('ur_robot_driver')
+    robot_controller_file = os.path.join(controller_package_path, 'config', 'ur5_controllers.yaml')
+    
+    with open(robot_description_file, 'r') as infile:
+        descr = infile.read()
+    robot_description = {'robot_description': descr}
+
+
+    return LaunchDescription([
+      Node(
+        package='controller_manager',
+        executable='ros2_control_node',
+        parameters=[robot_description, robot_controller_file],
+        output={
+          'stdout': 'screen',
+          'stderr': 'screen',
+          },
+        )
+    ])

--- a/ur_robot_driver/package.xml
+++ b/ur_robot_driver/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ur_robot_driver</name>
   <version>0.0.0</version>
@@ -26,6 +26,8 @@
 
   <depend>ur_client_library</depend>
   <depend>ur_dashboard_msgs</depend>
+
+  <exec_depend>controller_manager</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/ur_robot_driver/package.xml
+++ b/ur_robot_driver/package.xml
@@ -1,10 +1,16 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ur_robot_driver</name>
   <version>0.0.0</version>
   <description>The new driver for Universal Robots UR3, UR5 and UR10 robots with CB3 controllers and the e-series.</description>
+  <author>Thomas Timm Andersen</author>
+  <author>Simon Rasmussen</author>
+  <author>Felix Exner</author>
+  <author>Lea Steffen</author>
+  <author>Tristan Schnell</author>
   <maintainer email="exner@fzi.de">Felix Exner</maintainer>
+  <!-- TODO(andyz): look into license situation -->
   <license>Apache-2.0</license>
   <license>BSD-2-Clause</license>
   <license>Zlib</license>
@@ -13,21 +19,16 @@
   <url type="bugtracker">https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues</url>
   <url type="repository">https://github.com/UniversalRobots/Universal_Robots_ROS_Driver</url>
 
-  <author>Thomas Timm Andersen</author>
-  <author>Simon Rasmussen</author>
-  <author>Felix Exner</author>
-  <author>Lea Steffen</author>
-  <author>Tristan Schnell</author>
-
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>hardware_interface</buildtool_depend>
+  <buildtool_depend>pluginlib</buildtool_depend>
+  <buildtool_depend>rclcpp</buildtool_depend>
 
   <depend>ur_client_library</depend>
   <depend>ur_dashboard_msgs</depend>
 
   <export>
     <build_type>ament_cmake</build_type>
-    <hardware_interface plugin="${prefix}/hardware_interface_plugin.xml" />
-    <rosdoc config="doc/rosdoc.yaml" />
   </export>
 
 </package>

--- a/ur_robot_driver/src/dashboard_client_ros.cpp
+++ b/ur_robot_driver/src/dashboard_client_ros.cpp
@@ -29,5 +29,4 @@
 
 namespace ur_robot_driver
 {
-
 }  // namespace ur_robot_driver

--- a/ur_robot_driver/src/dashboard_client_ros.cpp
+++ b/ur_robot_driver/src/dashboard_client_ros.cpp
@@ -27,6 +27,7 @@
 
 #include <ur_robot_driver/dashboard_client_ros.h>
 
-namespace ur_driver
+namespace ur_robot_driver
 {
-}  // namespace ur_driver
+
+}  // namespace ur_robot_driver

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -19,8 +19,8 @@
 //----------------------------------------------------------------------
 /*!\file
  *
- * \author  Felix Exner exner@fzi.de
- * \date    2019-04-11
+ * \author  Andy Zelenak zelenak@picknik.ai
+ * \date    2020-11-9
  *
  */
 //----------------------------------------------------------------------
@@ -28,4 +28,23 @@
 
 namespace ur_robot_driver
 {
+  hardware_interface::return_type URHardwareInterface::configure(const HardwareInfo& system_info)
+  {
+    info_ = system_info;
+    status_ = status::CONFIGURED;
+
+    current_joint_angles_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
+    joint_angle_commands_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
+
+    for (const hardware_interface::ComponentInfo & joint : info_.joints)
+    {
+      if (joint.type.compare("ros2_control_components/PositionJoint") != 0)
+      {
+        status_ = status::UNKNOWN;
+        return return_type::ERROR;
+      }
+    }
+
+    return return_type::OK;
+  }
 }  // namespace ur_robot_driver

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -26,6 +26,7 @@
 //----------------------------------------------------------------------
 #include <ur_robot_driver/hardware_interface.h>
 
-namespace ur_driver
+namespace ur_robot_driver
 {
-}  // namespace ur_driver
+
+}  // namespace ur_robot_driver

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -28,23 +28,23 @@
 
 namespace ur_robot_driver
 {
-  hardware_interface::return_type URHardwareInterface::configure(const HardwareInfo& system_info)
+hardware_interface::return_type URHardwareInterface::configure(const HardwareInfo& system_info)
+{
+  info_ = system_info;
+  status_ = status::CONFIGURED;
+
+  current_joint_angles_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
+  joint_angle_commands_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
+
+  for (const hardware_interface::ComponentInfo& joint : info_.joints)
   {
-    info_ = system_info;
-    status_ = status::CONFIGURED;
-
-    current_joint_angles_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
-    joint_angle_commands_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
-
-    for (const hardware_interface::ComponentInfo & joint : info_.joints)
+    if (joint.type.compare("ros2_control_components/PositionJoint") != 0)
     {
-      if (joint.type.compare("ros2_control_components/PositionJoint") != 0)
-      {
-        status_ = status::UNKNOWN;
-        return return_type::ERROR;
-      }
+      status_ = status::UNKNOWN;
+      return return_type::ERROR;
     }
-
-    return return_type::OK;
   }
+
+  return return_type::OK;
+}
 }  // namespace ur_robot_driver

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -28,5 +28,4 @@
 
 namespace ur_robot_driver
 {
-
 }  // namespace ur_robot_driver

--- a/ur_robot_driver/src/robot_state_helper.cpp
+++ b/ur_robot_driver/src/robot_state_helper.cpp
@@ -28,6 +28,6 @@
 #include <ur_robot_driver/robot_state_helper.h>
 
 #include <std_srvs/srv/trigger.hpp>
-namespace ur_driver
+namespace ur_robot_driver
 {
-}  // namespace ur_driver
+}  // namespace ur_robot_driver

--- a/ur_robot_driver/src/robot_state_helper_node.cpp
+++ b/ur_robot_driver/src/robot_state_helper_node.cpp
@@ -27,7 +27,7 @@
 
 #include <ur_robot_driver/robot_state_helper.h>
 
-using namespace ur_driver;
+using namespace ur_robot_driver;
 
 int main(int argc, char** argv)
 {


### PR DESCRIPTION
This sets up the framework for the hardware_interface.

- Inherits from `hardware_interface::components::SystemInterface`
- Changes namespaces in the ur_robot_driver package to match the package name (IIRC this is a ROS convention)
- The launch file (ur5_bringup.launch.py) does not work yet due to this ros2_control issue: https://github.com/ros-controls/ros2_control/issues/229

I'm not sure if anybody is available to review this yet. Maybe @gavanderhoorn? If not, I'll let it simmer a day or so before merging to `develop`