### PR TITLE
Clean up ros2_control "return type" warning

### DIFF
--- a/ur_controllers/src/force_torque_sensor_controller.cpp
+++ b/ur_controllers/src/force_torque_sensor_controller.cpp
@@ -24,7 +24,7 @@ ForceTorqueStateController::ForceTorqueStateController()
 controller_interface::return_type ForceTorqueStateController::init(const std::string& controller_name)
 {
   auto ret = ControllerInterface::init(controller_name);
-  if (ret != controller_interface::return_type::SUCCESS)
+  if (ret != controller_interface::return_type::OK)
   {
     return ret;
   }
@@ -43,7 +43,7 @@ controller_interface::return_type ForceTorqueStateController::init(const std::st
     return controller_interface::return_type::ERROR;
   }
 
-  return controller_interface::return_type::SUCCESS;
+  return controller_interface::return_type::OK;
 }
 
 controller_interface::InterfaceConfiguration ForceTorqueStateController::command_interface_configuration() const
@@ -110,7 +110,7 @@ controller_interface::return_type ur_controllers::ForceTorqueStateController::up
   // publish
   wrench_state_publisher_->publish(wrench_state_msg_);
 
-  return controller_interface::return_type::SUCCESS;
+  return controller_interface::return_type::OK;
 }
 
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn

--- a/ur_controllers/src/scaled_joint_trajectory_controller.cpp
+++ b/ur_controllers/src/scaled_joint_trajectory_controller.cpp
@@ -62,7 +62,7 @@ controller_interface::return_type ScaledJointTrajectoryController::update()
       halt();
       is_halted = true;
     }
-    return controller_interface::return_type::SUCCESS;
+    return controller_interface::return_type::OK;
   }
 
   auto resize_joint_trajectory_point = [](trajectory_msgs::msg::JointTrajectoryPoint& point, size_t size) {
@@ -217,7 +217,7 @@ controller_interface::return_type ScaledJointTrajectoryController::update()
   }
 
   publish_state(state_desired, state_current, state_error);
-  return controller_interface::return_type::SUCCESS;
+  return controller_interface::return_type::OK;
 }
 
 }  // namespace ur_controllers

--- a/ur_controllers/src/speed_scaling_state_controller.cpp
+++ b/ur_controllers/src/speed_scaling_state_controller.cpp
@@ -110,7 +110,7 @@ controller_interface::return_type SpeedScalingStateController::update()
     speed_scaling_state_publisher_->publish(speed_scaling_state_msg_);
     last_publish_time_ = node_->now();
   }
-  return controller_interface::return_type::SUCCESS;
+  return controller_interface::return_type::OK;
 }
 
 }  // namespace ur_controllers


### PR DESCRIPTION
`controller_interface::return_type::SUCCESS` is deprecated