### PR TITLE
Fix move to home bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,6 @@ Beta version of the ROS2 Universal Robots driver. Should be transferred to the U
 
 ## Known Issues
 
-- **ATTENTION**: The robot could move to all-zero joint positions when starting.
-
-- **ATTENTION**: If the robot is connected to the ROS2 driver then moved using the teach pendant its position will not always be updated in the driver. This can cause unexpected movement of the robot when connected to the ROS2 driver again.
-
 - GPIO outputs are set continuously from the ROS2 driver therefore there is no possibility to change them from the teach pendant.
 
 ## Packages in the Repository:

--- a/ur_controllers/src/scaled_joint_trajectory_controller.cpp
+++ b/ur_controllers/src/scaled_joint_trajectory_controller.cpp
@@ -89,8 +89,7 @@ controller_interface::return_type ScaledJointTrajectoryController::update()
   resize_joint_trajectory_point(state_current, joint_num);
 
   // current state update
-  for (size_t index = 0; index < joint_num; ++index)
-  {
+  for (size_t index = 0; index < joint_num; ++index) {
     state_current.positions[index] = joint_position_state_interface_[index].get().get_value();
     state_current.velocities[index] = joint_velocity_state_interface_[index].get().get_value();
     state_current.accelerations[index] = 0.0;
@@ -99,12 +98,6 @@ controller_interface::return_type ScaledJointTrajectoryController::update()
 
   // currently carrying out a trajectory
   if (traj_point_active_ptr_ && !(*traj_point_active_ptr_)->has_trajectory_msg()) {
-    // if sampling the first time, set the point before you sample
-    if (!(*traj_point_active_ptr_)->is_sampled_already()) {
-      (*traj_point_active_ptr_)->set_point_before_trajectory_msg(node_->now(), state_current);
-    }
-    resize_joint_trajectory_point(state_error, joint_num);
-
     // Main Speed scaling difference...
     // Adjust time with scaling factor
     TimeData time_data;
@@ -115,6 +108,12 @@ controller_interface::return_type ScaledJointTrajectoryController::update()
     rclcpp::Time traj_time = time_data_.readFromRT()->uptime + rclcpp::Duration(period);
     time_data_.writeFromNonRT(time_data);
 
+    // if sampling the first time, set the point before you sample
+    if (!(*traj_point_active_ptr_)->is_sampled_already()) {
+      (*traj_point_active_ptr_)->set_point_before_trajectory_msg(traj_time, state_current);
+    }
+    resize_joint_trajectory_point(state_error, joint_num);
+
     // find segment for current timestamp
     joint_trajectory_controller::TrajectoryPointConstIter start_segment_itr, end_segment_itr;
     const bool valid_point =
@@ -124,8 +123,7 @@ controller_interface::return_type ScaledJointTrajectoryController::update()
       bool abort = false;
       bool outside_goal_tolerance = false;
       const bool before_last_point = end_segment_itr != (*traj_point_active_ptr_)->end();
-      for (size_t index = 0; index < joint_num; ++index)
-      {
+      for (size_t index = 0; index < joint_num; ++index) {
         // set values for next hardware write()
         joint_position_command_interface_[index].get().set_value(state_desired.positions[index]);
         compute_error_for_joint(state_error, index, state_current, state_desired);

--- a/ur_robot_driver/include/ur_robot_driver/hardware_interface.hpp
+++ b/ur_robot_driver/include/ur_robot_driver/hardware_interface.hpp
@@ -167,7 +167,6 @@ protected:
 
   bool robot_program_running_;
   bool non_blocking_read_;
-  bool position_interface_in_use_;
 
   PausingState pausing_state_;
   double pausing_ramp_up_increment_;


### PR DESCRIPTION
* Before sending data to the robot the hardware interface not verifies if the controller has send new data or if the current joint values are just stale output.
* Fixed a timing issue in the scaled trajectory controller. When executing multiple trajectories subsequently, the scaled timing was not handled correctly which caused a delay of the starting point of the trajectory.
* Removed **Attention** Flags related to move to home bug in the Readme file