### PR TITLE
Reintegrating missing ur_client_library dependency since the break the building process

### DIFF
--- a/ur_controllers/package.xml
+++ b/ur_controllers/package.xml
@@ -32,7 +32,7 @@
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
   <!-- TODO: rosdep cannot find ur_client_library -->
-<!--   <depend>ur_client_library</depend> -->
+  <depend>ur_client_library</depend> 
   <depend>ur_dashboard_msgs</depend>
   <depend>ur_msgs</depend>
 

--- a/ur_controllers/package.xml
+++ b/ur_controllers/package.xml
@@ -32,7 +32,7 @@
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
   <!-- TODO: rosdep cannot find ur_client_library -->
-  <depend>ur_client_library</depend> 
+  <depend>ur_client_library</depend>
   <depend>ur_dashboard_msgs</depend>
   <depend>ur_msgs</depend>
 

--- a/ur_robot_driver/package.xml
+++ b/ur_robot_driver/package.xml
@@ -28,7 +28,7 @@
   <depend>rclcpp</depend>
   <depend>std_srvs</depend>
   <!-- TODO: rosdep cannot find ur_client_library -->
-<!--   <depend>ur_client_library</depend> -->
+  <depend>ur_client_library</depend> 
   <depend>ur_dashboard_msgs</depend>
 
   <exec_depend>controller_manager</exec_depend>

--- a/ur_robot_driver/package.xml
+++ b/ur_robot_driver/package.xml
@@ -28,7 +28,7 @@
   <depend>rclcpp</depend>
   <depend>std_srvs</depend>
   <!-- TODO: rosdep cannot find ur_client_library -->
-  <depend>ur_client_library</depend> 
+  <depend>ur_client_library</depend>
   <depend>ur_dashboard_msgs</depend>
 
   <exec_depend>controller_manager</exec_depend>


### PR DESCRIPTION
This might break the ci pipeline but otherwise the driver is not build-able for new users which is in my opinion worse than a broken ci